### PR TITLE
[romeo_gazebo_plugin/README.rst] clone using https

### DIFF
--- a/romeo_gazebo_plugin/README.rst
+++ b/romeo_gazebo_plugin/README.rst
@@ -16,7 +16,7 @@ Other plugins to fetch and compile:
 
 .. code-block:: bash
 
-    git clone git@github.com:roboticsgroup/roboticsgroup_gazebo_plugins.git
+    git clone https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
     catkin_make
 
 Please also make sure that the package and all the dependencies are up to date


### PR DESCRIPTION
`git clone` command now use https rather than ssh for repository cloning. This is temporary until we get rid of the dependency on roboticsgroup_gazebo_plugins. This should address issues like https://github.com/ros-naoqi/pepper_virtual/issues/8#issue-196955822